### PR TITLE
resolve bug 1

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings = 
+    once

--- a/spenc/abstracts.py
+++ b/spenc/abstracts.py
@@ -243,6 +243,9 @@ class SPENC(clust.SpectralClustering):
         """
         if np.isinf(self.n_clusters):
             self.assign_labels='hierarchical'
+        
+        if W is None:
+            W = sparse.csc_matrix(np.ones_like(X.shape[0],X.shape[0]))
 
         if X is not None:
             X = check_array(X, accept_sparse = ['csr','coo', 'csc'],
@@ -255,7 +258,7 @@ class SPENC(clust.SpectralClustering):
                                                 include_self=True, n_jobs=self.n_jobs)
                 self.attribute_affinity_ = .5 * (connectivity + connectivity.T)
             elif self.affinity == 'precomputed':
-                self.attribute_affinity_ = X
+                self.attribute_affinity_ = W.multiply(X)
             else:
                 params = self.kernel_params
                 if params is None:

--- a/spenc/abstracts.py
+++ b/spenc/abstracts.py
@@ -496,6 +496,16 @@ class SPENC(clust.SpectralClustering):
         spatial_score = spatial_score(W,labels, X=X,**spatial_kw)
         return delta * attribute_score + (1 - delta)*spatial_score
 
+    def gain(self, labels=None, metric=skm.adjusted_rand_score):
+        """Change in assignment from pure spatial/pure attribute assignments"""
+        if labels is None:
+            if not hasattr(self, 'labels_'):
+                raise Exception("Must provide labels or have fit in order to compute gain.")
+            labels = self.labels_
+        purespace = self.fit(None, self.W)
+        pureatts = self.fit(self.attribute_affinity_, np.ones_like(self.W))
+        return metric(purespace.labels_, labels), metric(pureatts.labels_, labels)
+
     def _sample_gen(self, W, n_samples=1, 
                             affinity='rbf',
                             distribution=None, **fit_kw):

--- a/spenc/abstracts.py
+++ b/spenc/abstracts.py
@@ -253,9 +253,9 @@ class SPENC(clust.SpectralClustering):
             if self.affinity == 'nearest_neighbors':
                 connectivity = kneighbors_graph(X, n_neighbors=self.n_neighbors,
                                                 include_self=True, n_jobs=self.n_jobs)
-                self.affinity_matrix_ = .5 * (connectivity + connectivity.T)
+                self.attribute_affinity_ = .5 * (connectivity + connectivity.T)
             elif self.affinity == 'precomputed':
-                self.affinity_matrix_ = X
+                self.attribute_affinity_ = X
             else:
                 params = self.kernel_params
                 if params is None:
@@ -267,8 +267,8 @@ class SPENC(clust.SpectralClustering):
                 self.attribute_affinity_ = pw.pairwise_kernels(X, metric=self.affinity,
                                                                filter_params=True,
                                                                **params)
-                self.spatial_affinity_ = W
-                self.affinity_matrix_ = W.multiply(self.attribute_affinity_)
+            self.spatial_affinity_ = W
+            self.affinity_matrix_ = W.multiply(self.attribute_affinity_)
         else:
             self.affinity_matrix_ = W
         if breakme: ##sklearn/issues/8129


### PR DESCRIPTION
This switches to use `attribute_affinity_` when `affinity='precomputed'`, rather than letting it pass through all the way down, without filtering by `W`. 